### PR TITLE
Update 2012-08-02-rest-apis-with-symfony2-the-right-way.markdown

### DIFF
--- a/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
+++ b/_posts/2012-08-02-rest-apis-with-symfony2-the-right-way.markdown
@@ -886,7 +886,7 @@ which allows you to call your API methods directly in your test classes:
 $client   = static::createClient();
 $crawler  = $client->request('GET', '/users');
 
-$response = $crawler->getResponse();
+$response = $client->getResponse();
 
 $this->assertJsonResponse($response, 200);
 ```


### PR DESCRIPTION
The method getResponse should be called on $client